### PR TITLE
Trim spaces when updating items too

### DIFF
--- a/src/TodoMVC.elm
+++ b/src/TodoMVC.elm
@@ -202,12 +202,12 @@ updateState action model =
           Just (id1, title) ->
             if (id == id1)
             then
-              if title == ""
+              if title |> String.trim |> String.isEmpty
               then
                 effectItems <| ElmFire.Op.remove id
               else
                 effectItems <| ElmFire.Op.update id
-                  ( Maybe.map (\item -> { item | title <- title }) )
+                  ( Maybe.map (\item -> { item | title <- title |> String.trim }) )
             else Effects.none
           _ -> Effects.none
       )


### PR DESCRIPTION
Changing an existing item to only spaces should have the same
effect as deleting all characters, i.e. deleting the item from
the list.

Apologies for not noticing this in yesterday's PR.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thomasweiser/todomvc-elmfire/3)

<!-- Reviewable:end -->
